### PR TITLE
Use app.provide to inject storage instances

### DIFF
--- a/src/vue.ts
+++ b/src/vue.ts
@@ -8,6 +8,7 @@ const registerInstance = (app: App, driver: driverType, prefix: string) => {
   const apiName = '$' + String(driver) + 'Storage';
 
   app.config.globalProperties[apiName] = instance;
+  app.provide(apiName, instance);
 };
 
 export interface PluginOptions {


### PR DESCRIPTION
https://v3.vuejs.org/api/application-api.html#provide

This is cleaner to use when using the composition API, since it can be as simple as `inject<StorageWithEvent>("$localStorage")`.